### PR TITLE
Quit gracefully on kill signal

### DIFF
--- a/generals/rendering.py
+++ b/generals/rendering.py
@@ -53,14 +53,14 @@ class Renderer:
             'time_change': 0,
         }
         for event in pygame.event.get():
-            if event.type == pygame.QUIT:
+            if event.type == pygame.QUIT or (
+                event.type == pygame.KEYDOWN and event.key == pygame.K_q
+            ):
                 pygame.quit()
+                quit()
             if event.type == pygame.KEYDOWN:
                 self.changed = True
                 control_events['changed'] = True
-                if event.key == pygame.K_q:
-                    pygame.quit()
-                    quit()
 
                 # Speed up game right arrow is pressed
                 if event.key == pygame.K_RIGHT and not self.paused:


### PR DESCRIPTION
Before, exiting via `kill` command resulted in following error:
```
python3 -m examples.example
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File ".../Generals-Zoo/examples/example.py", line 33, in <modu
    env.render(tick_rate=actions_per_second)
  File ".../Generals-Zoo/generals/env.py", line 44, in render
    self.renderer.render()
  File ".../Generals-Zoo/generals/rendering.py", line 94, in ren
    self.render_grid()
  File ".../Generals-Zoo/generals/rendering.py", line 205, in re
    self.draw_channel(visibility_indices, c.WHITE)
  File ".../Generals-Zoo/generals/rendering.py", line 304, in dr
    pygame.draw.rect(
pygame.error: display Surface quit
make: *** [Makefile:7: run] Error 1

```