### PR TITLE
fix(gui): keep self-play players distinct when agents share a name

### DIFF
--- a/generals/gui/replay_gui.py
+++ b/generals/gui/replay_gui.py
@@ -46,6 +46,12 @@ class ReplayGUI:
             show_tile_types: If True, show tile type labels (0, -2, C40, etc.) for debugging.
         """
         self.agent_ids = agent_ids or ["Player 0", "Player 1"]
+        # The rendering adapters key every per-player dict (ownership, generals,
+        # colors, fov, stats) by name, so two identically-named agents (e.g. a
+        # self-play match) would collapse both players onto one entry. Keep names
+        # distinct for display so each player keeps its own slot.
+        if self.agent_ids[0] == self.agent_ids[1]:
+            self.agent_ids = [f"{self.agent_ids[0]} (P0)", f"{self.agent_ids[1]} (P1)"]
         colors = colors or ["red", "blue"]
         self.fps = fps
 


### PR DESCRIPTION
## Bug

When two agents share a name (a self-play match, or `matchup.py` running the same agent on both sides — it passes `[a0.parent.name, a1.parent.name]`), rendering breaks: only one player's territory and general show up, both score rows display the same name/color/identical stats, and the board looks like one player owns everything.

## Cause

The rendering adapters key **every per-player structure by agent name**, and names aren't unique. Identical names → duplicate dict keys → each collapses from 2 entries to 1 (player 1 overwrites player 0):

| dict | location |
|---|---|
| `channels.ownership` | `core/rendering.py:43` |
| `general_positions` | `core/rendering.py:87` |
| `agent_data` (color) | `replay_gui.py:54` |
| `agent_fov` | `properties.py:36` |
| `get_infos()` stats | `core/rendering.py` |

## Fix

All of those derive from `ReplayGUI.agent_ids`, so de-duplicate the display names once at that single fan-out point (`X` → `X (P0)` / `X (P1)`). Fixes ownership + generals + colors + fov + stats together, touches nothing in the simulator, and works for every caller including `matchup.py`.

Verified headless: with `agent_ids=["Bot","Bot"]`, the adapter previously had 1 general / 1 ownership map; after the fix `ReplayGUI` yields `['Bot (P0)','Bot (P1)']` and the adapter keeps 2 of each.

The proper long-term fix is to key these structures by player **index** and treat names as display-only labels; this is the minimal, low-risk version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)